### PR TITLE
Step8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,10 @@ dependencies {
 
     // validator
     implementation 'commons-validator:commons-validator:1.7'
+
+    // shedlock
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:6.3.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.3.0'
 }
 
 test {

--- a/docs/서비스내_병목현상_개선_보고서.md
+++ b/docs/서비스내_병목현상_개선_보고서.md
@@ -1,0 +1,163 @@
+# 서비스 내 병목현상 개선 보고서
+
+## 1) 서론
+
+병목현상이란 시스템 내에서 특정 단계가 전체 처리 속도를 제약해 주된 작업 흐름을 저해하는 현상을 말합니다. 본 보고서에서는 서비스 전반에 걸친 조회 기능 중 특히 **인기 상품 조회**에서 심각하게 나타나는 병목 현상과 그로인한 성능 저하의 원인을 규명하고, 이를 해결하기 위한 방안을 제시하고자 합니다.
+
+## 2) 서비스 내 조회 기능 리스트업
+
+서비스 내 주요 조회 기능과 병목 발생 여부는 다음과 같습니다:
+
+| 기능               | 병목 여부 | 설명                                                                                                                                                         |
+| ------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 상품 목록 조회     | X         | 검색 조건 없이 단순 목록을 조회하는 기능으로 페이징 처리시 오프셋이 작다면 PK에 적용된 클러스터형 인덱스로 인해 병목 발생하지 않음                           |
+| 상품 상세 조회     | X         | 상품 ID로 단일 조회하는 기능으로 PK로 조회하기 때문에 인덱스가 적용되어 있어 병목 발생하지 않음                                                              |
+| 쿠폰 목록 조회     | X         | 검색 조건 없이 단순 목록을 조회하는 기능으로 페이징 처리시 오프셋이 작다면 PK에 적용된 클러스터형 인덱스로 인해 병목 발생하지 않음                           |
+| **인기 상품 조회** | **O**     | 최근 한 달간 주문된 상품을 기준으로 집계 및 정렬을 수행하여 인기 상품을 조회하는 기능으로, 대량의 데이터를 처리하며 임시 테이블과 정렬이 발생하여 병목 발생 |
+
+## 3) 병목 쿼리 분석
+
+#### 기존 쿼리 (병목 발생)
+
+인기 상품 조회 시 사용되던 기존 쿼리는 다음과 같습니다:
+
+```sql
+-- 최근 1개월간 가장 많이 팔린 상품 상위 5개 조회
+SELECT po.product_id
+FROM orders o
+JOIN order_items oi ON oi.order_id = o.id
+JOIN product_options po ON po.id = oi.product_option_id
+WHERE o.status = 'COMPLETED'
+  AND o.created_at > NOW() - INTERVAL 1 MONTH
+GROUP BY po.product_id
+ORDER BY COUNT(*) DESC
+LIMIT 5;
+```
+
+#### EXPLAIN ANALYZE 결과 (기존 쿼리)
+
+```sql
+-> Limit: 5 row(s)  (actual time=2542..2542 rows=5 loops=1)
+  -> Sort: `COUNT(*)` DESC, limit input to 5 row(s) per chunk  (actual time=2542..2542 rows=5 loops=1)
+    -> Table scan on <temporary>  (actual time=2541..2541 rows=6394 loops=1)
+      -> Aggregate using temporary table  (actual time=2541..2541 rows=6394 loops=1)
+        -> Nested loop inner join  (cost=182866 rows=74694) (actual time=442..2382 rows=490650 loops=1)
+          -> Nested loop inner join  (cost=156723 rows=74694) (actual time=442..1829 rows=490650 loops=1)
+            -> Filter: ((o.`status` = 'COMPLETED') and (o.created_at > <cache>((now() - interval 1 month))))  (cost=102430 rows=49745) (actual time=442..735 rows=327088 loops=1)
+              -> Table scan on o  (cost=102430 rows=994896) (actual time=4.42..571 rows=1e+6 loops=1)
+            -> Index lookup on oi using order_items_order_id_index (order_id=o.id)  (cost=0.941 rows=1.5) (actual time=0.00292..0.0032 rows=1.5 loops=327088)
+          -> Single-row index lookup on po using PRIMARY (id=oi.product_option_id)  (cost=0.25 rows=1) (actual time=0.00098..0.001 rows=1 loops=490650)
+```
+
+#### 분석 결과
+
+- **대규모 데이터 스캔**: 총 주문 약 100만 건 중 최근 한 달 주문이 약 50만 건을 차지하여 `orders` 테이블 풀 스캔에 가까운 작업 발생
+- **인덱스 비효율**: 최근 한달 주문이 약 50만건을 차지 하여 `created_at` 조건의 필터링 효과가 미미하여 인덱스를 효과적으로 활용하지 못함
+- **임시 테이블 사용**: 집계 과정에서 임시 테이블을 사용하여 추가적인 I/O 및 처리 시간 발생
+- **실행 시간**: 약 2.5초 소요되어 사용자 경험 저하
+
+## 4) 해결 방안 모색
+
+#### 대안 1: 캐싱
+
+- **내용**: Redis와 같은 인메모리 캐싱을 활용하여 병목 쿼리 결과를 저장하고 재사용
+- **결과**: 현재 외부 인프라 사용 제약으로 적용 불가하며 근본적으로 슬로우 쿼리에 대한 개선안이 아님
+
+#### 대안 2: 통계 테이블 (선택)
+
+- **내용**: 매일 자정에 배치 작업을 통해 일별 상품 판매 데이터를 집계하여 별도의 통계 테이블(`daily_product_sales`)에 저장. 조회 시에는 이 통계 테이블만 사용
+- **장점**: 외부 인프라 없이 구현 가능, 조회 시 복잡한 조인 및 실시간 집계 제거 (조회 성능 개선)
+- **단점**: 집계 시간 동안 쓰기 부하 발생, 데이터 지연 발생(실시간 X)
+
+#### 통계 테이블 구조 (DDL)
+
+선택된 방안에 따라 설계된 통계 테이블 구조는 다음과 같습니다:
+
+```sql
+CREATE TABLE daily_product_sales (
+    id BIGINT AUTO_INCREMENT COMMENT '일일 통계 ID' PRIMARY KEY,
+    aggregation_date DATE NOT NULL COMMENT '집계 날짜',
+    product_id BIGINT NOT NULL COMMENT '상품 ID',
+    order_count INT DEFAULT 0 NOT NULL COMMENT '완료된 주문 수',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL COMMENT '생성 시간',
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 시간',
+    UNIQUE KEY uk_daily_product_sales_aggregation_date_product_id (aggregation_date, product_id),
+    INDEX dps_covering_index (aggregation_date, product_id, order_count) -- 커버링 인덱스
+) COMMENT='일일 상품 판매 통계 테이블';
+```
+
+## 5) 설계 및 구현
+
+#### 집계 프로세스 (시퀀스 다이어그램)
+
+```mermaid
+sequenceDiagram
+  participant Scheduler as Scheduler
+  participant Service as StatsService
+  participant ProductRepo as ProductRepository
+  participant StatsRepo as StatsRepository
+
+  Scheduler->>Service: 일일 통계 집계 요청
+  loop Chunk 단위 처리
+    Service->>ProductRepo: 상품 ID 조회 (Chunk 단위)
+    ProductRepo-->>Service: 상품 ID 목록 반환
+    Service->>StatsRepo: 판매 데이터 집계 요청
+    StatsRepo-->>Service: 집계 결과 전달
+    Service->>StatsRepo: 통계 데이터 저장 (batch insert)
+  end
+  Service-->>Scheduler: 집계 완료
+```
+
+#### 구현 상세
+
+배치 작업을 통한 통계 테이블 기반 접근법을 다음과 같이 구현했습니다:
+
+1.  **스케줄러 구성**: Spring의 `@Scheduled` 어노테이션과 `ShedLock`을 사용하여 매일 자정 안정적으로 실행되는 스케줄러 구성
+2.  **메모리 효율성**: 전체 상품을 1,000개 단위 청크로 분할 처리하여 메모리 사용량 최적화
+3.  **성능 최적화**: `JdbcTemplate`을 활용한 배치 INSERT로 쓰기 성능 확보. 커버링 인덱스 설계로 조회 성능 극대화
+4.  **통계 데이터 조회**: 인기 상품 조회 시, 집계된 통계 테이블에서 `orderCount` 합계 기준 상위 상품 ID를 조회하고, 이 ID 목록으로 실제 상품 정보 조회
+
+`ShedLock`란? 다중 인스턴스 환경에서 스케줄러가 중복 실행되지 않도록 Lock을 관리하는 라이브러리입니다. 이를 통해 안정적인 배치 작업을 보장합니다.
+
+## 6) 결과
+
+#### 개선된 쿼리
+
+```sql
+-- 통계 테이블에서 최근 1개월간 판매량 상위 5개 상품 ID 조회
+SELECT product_id
+FROM daily_product_sales
+WHERE aggregation_date > NOW() - INTERVAL 1 MONTH
+GROUP BY product_id
+ORDER BY SUM(order_count) DESC
+LIMIT 5;
+```
+
+#### EXPLAIN ANALYZE 결과 (개선된 쿼리)
+
+```sql
+-> Limit: 5 row(s)  (actual time=108..108 rows=5 loops=1)
+  -> Sort: total_cnt DESC, limit input to 5 row(s) per chunk  (actual time=108..108 rows=5 loops=1)
+    -> Table scan on <temporary>  (actual time=107..108 rows=6394 loops=1)
+      -> Aggregate using temporary table  (actual time=107..107 rows=6394 loops=1)
+        -> Filter: (daily_product_sales.aggregation_date > <cache>((now() - interval 1 month)))  (cost=61436 rows=302932) (actual time=0.892..55.8 rows=226647 loops=1)
+          -> Covering index range scan on daily_product_sales using dps_covering_index over ('2025-03-17' < aggregation_date)  (cost=61436 rows=302932) (actual time=0.876..41.8 rows=226647 loops=1)
+```
+
+#### 성능 비교
+
+| 구분             | 기존 방식             | 개선 방식                    | 개선율  |
+| :--------------- | :-------------------- | :--------------------------- | :------ |
+| **처리 시간**    | **약 2500ms**         | **약 100ms**                 | **95%** |
+| 데이터 조회 방식 | 직접 주문 테이블 조인 | 사전 집계된 통계 테이블 조회 | -       |
+| 인덱스 활용      | 비효율적              | 커버링 인덱스 활용           | -       |
+| 부하 발생        | 실시간 집계 쿼리      | 미리 집계된 데이터 조회      | -       |
+| 메모리 사용량    | 높음                  | 낮음                         | -       |
+
+**분석**: 통계 테이블과 커버링 인덱스 사용으로 테이블 스캔 범위와 처리 데이터 양이 크게 줄었으며, 복잡한 조인과 실시간 집계가 사라져 처리 시간이 95% 단축되었습니다.
+
+## 7) 마치며
+
+통계 테이블을 활용한 일일 배치 집계 방식은 **인기 상품 조회 기능의 병목 현상을 효과적으로 해결**했습니다. 이 방식은 외부 인프라 의존 없이 Spring Boot의 내장 기능만으로 구현 가능하며, 데이터 증가에도 안정적인 성능을 제공합니다.
+
+향후 서비스 확장 및 트래픽 증가 시, Redis 등 인메모리 캐싱을 추가로 도입, Spring Batch와 같은 배치 처리 프레임워크를 활용하여 대량 데이터 처리 및 성능 최적화를 진행하면 더욱 효율적인 시스템을 구축할 수 있을 것입니다.

--- a/src/main/java/kr/hhplus/ecommerce/application/product/ProductFacade.java
+++ b/src/main/java/kr/hhplus/ecommerce/application/product/ProductFacade.java
@@ -1,24 +1,25 @@
 package kr.hhplus.ecommerce.application.product;
 
-import java.util.List;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import kr.hhplus.ecommerce.domain.order.OrderService;
 import kr.hhplus.ecommerce.domain.product.ProductService;
 import kr.hhplus.ecommerce.domain.product.ProductVo;
+import kr.hhplus.ecommerce.domain.statistics.DailyProductSalesService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ProductFacade {
     private final OrderService orderService;
     private final ProductService productService;
+    private final DailyProductSalesService dailyProductSalesService;
     
     @Transactional(readOnly = true)
     public List<ProductVo> findTopSellingProducts(int limit) {
-        List<Long> topProductIds = orderService.findTopSellingProductIds(limit);
+        List<Long> topProductIds = dailyProductSalesService.findTopSellingProductIds(limit);
         return productService.findAllById(topProductIds);
     }
 }

--- a/src/main/java/kr/hhplus/ecommerce/application/statistics/DailyProductSalesScheduler.java
+++ b/src/main/java/kr/hhplus/ecommerce/application/statistics/DailyProductSalesScheduler.java
@@ -1,0 +1,37 @@
+package kr.hhplus.ecommerce.application.statistics;
+
+import kr.hhplus.ecommerce.domain.statistics.DailyProductSalesService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DailyProductSalesScheduler {
+
+    private final DailyProductSalesService dailyProductSalesService;
+    
+    /**
+     * 매일 자정에 실행되어 전날의 판매 통계를 집계합니다.
+     */
+    @Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul")
+    @SchedulerLock(name = "aggregateDailyProductSales", lockAtLeastFor = "PT10M")
+    public void aggregateDailyProductSales() {
+        log.info("일일 상품 판매 통계 집계 작업 시작");
+        // 환불 건이 존재할 수 있음으로 일주일 이전 데이터부터 새로 집계
+        LocalDate from = LocalDate.now().minusDays(8);
+        LocalDate to = LocalDate.now().minusDays(1);
+
+        try {
+            dailyProductSalesService.aggregate(from, to);
+            log.info("일일 상품 판매 통계 집계 작업 완료");
+        } catch (Exception e) {
+            log.error("일일 상품 판매 통계 집계 작업 실패", e);
+        }
+    }
+} 

--- a/src/main/java/kr/hhplus/ecommerce/config/ApplicationConfiguration.java
+++ b/src/main/java/kr/hhplus/ecommerce/config/ApplicationConfiguration.java
@@ -1,11 +1,12 @@
 package kr.hhplus.ecommerce.config;
 
-import kr.hhplus.ecommerce.common.web.CommonObjectMapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.hhplus.ecommerce.common.web.CommonObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.web.client.RestTemplate;
 
 import javax.sql.DataSource;
@@ -27,5 +28,10 @@ public class ApplicationConfiguration {
     @Bean
     JdbcTemplate jdbcTemplate(DataSource dataSource) {
         return new JdbcTemplate(dataSource);
+    }
+    
+    @Bean
+    NamedParameterJdbcTemplate namedParameterJdbcTemplate(DataSource dataSource) {
+        return new NamedParameterJdbcTemplate(dataSource);
     }
 }

--- a/src/main/java/kr/hhplus/ecommerce/config/SchedulerConfiguration.java
+++ b/src/main/java/kr/hhplus/ecommerce/config/SchedulerConfiguration.java
@@ -1,0 +1,21 @@
+package kr.hhplus.ecommerce.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import javax.sql.DataSource;
+
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT10M")
+@Configuration
+public class SchedulerConfiguration {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(dataSource);
+    }
+}

--- a/src/main/java/kr/hhplus/ecommerce/domain/coupon/IssuedCoupon.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/coupon/IssuedCoupon.java
@@ -14,6 +14,10 @@ import static kr.hhplus.ecommerce.common.support.DomainStatus.ALREADY_USED_COUPO
 import static kr.hhplus.ecommerce.common.support.DomainStatus.EXPIRED_COUPON;
 
 @Entity(name = "issued_coupons")
+@Table(indexes = {
+    @Index(name = "idx_issued_coupon_user_id", columnList = "userId"),
+    @Index(name = "idx_issued_coupon_coupon_id", columnList = "coupon_id")
+})
 @Getter
 @Accessors(fluent = true)
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)

--- a/src/main/java/kr/hhplus/ecommerce/domain/order/Order.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/order/Order.java
@@ -15,6 +15,10 @@ import java.util.List;
 import static kr.hhplus.ecommerce.common.support.DomainStatus.ALREADY_COMPLETED_ORDER;
 
 @Entity(name = "orders")
+@Table(indexes = {
+    @Index(name = "idx_order_user_id", columnList = "userId"),
+    @Index(name = "idx_order_issued_coupon_id", columnList = "issuedCouponId")
+})
 @Getter
 @Accessors(fluent = true)
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)

--- a/src/main/java/kr/hhplus/ecommerce/domain/order/OrderItem.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/order/OrderItem.java
@@ -4,6 +4,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import kr.hhplus.ecommerce.common.entity.BaseEntity;
 import kr.hhplus.ecommerce.domain.product.ProductOption;
 import lombok.Getter;
@@ -11,6 +13,9 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
 @Entity(name = "order_items")
+@Table(indexes = {
+    @Index(name = "idx_order_item_product_option_id", columnList = "productOptionId")
+})
 @Getter
 @Accessors(fluent = true)
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)

--- a/src/main/java/kr/hhplus/ecommerce/domain/payment/Payment.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/payment/Payment.java
@@ -9,6 +9,10 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
 @Entity(name = "payments")
+@Table(indexes = {
+    @Index(name = "idx_payment_order_id", columnList = "orderId"),
+    @Index(name = "idx_payment_user_id", columnList = "userId")
+})
 @Getter
 @Accessors(fluent = true)
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)

--- a/src/main/java/kr/hhplus/ecommerce/domain/point/UserPoint.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/point/UserPoint.java
@@ -3,16 +3,23 @@ package kr.hhplus.ecommerce.domain.point;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 import kr.hhplus.ecommerce.common.entity.BaseEntity;
 import kr.hhplus.ecommerce.common.exception.DomainException;
+import static kr.hhplus.ecommerce.common.support.DomainStatus.EXCEEDED_MAX_USER_POINT;
+import static kr.hhplus.ecommerce.common.support.DomainStatus.INSUFFICIENT_BALANCE;
+import static kr.hhplus.ecommerce.common.support.DomainStatus.INVALID_CHARGE_AMOUNT;
+import static kr.hhplus.ecommerce.common.support.DomainStatus.INVALID_USE_AMOUNT;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
-import static kr.hhplus.ecommerce.common.support.DomainStatus.*;
-
 @Entity(name = "user_points")
+@Table(indexes = {
+    @Index(name = "idx_user_point_user_id", columnList = "userId")
+})
 @Getter
 @Accessors(fluent = true)
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)

--- a/src/main/java/kr/hhplus/ecommerce/domain/point/UserPointHistory.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/point/UserPointHistory.java
@@ -4,12 +4,17 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import kr.hhplus.ecommerce.common.entity.BaseEntity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
 @Entity(name = "user_point_histories")
+@Table(indexes = {
+    @Index(name = "idx_user_point_history_user_id", columnList = "userId")
+})
 @Getter
 @Accessors(fluent = true)
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)

--- a/src/main/java/kr/hhplus/ecommerce/domain/product/ProductOption.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/product/ProductOption.java
@@ -1,16 +1,26 @@
 package kr.hhplus.ecommerce.domain.product;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import kr.hhplus.ecommerce.common.entity.BaseEntity;
 import kr.hhplus.ecommerce.common.exception.DomainException;
+import static kr.hhplus.ecommerce.common.support.DomainStatus.INSUFFICIENT_STOCK;
+import static kr.hhplus.ecommerce.common.support.DomainStatus.INVALID_PARAMETER;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
-import static kr.hhplus.ecommerce.common.support.DomainStatus.INSUFFICIENT_STOCK;
-import static kr.hhplus.ecommerce.common.support.DomainStatus.INVALID_PARAMETER;
-
 @Entity(name = "product_options")
+@Table(indexes = {
+    @Index(name = "idx_product_option_product_id", columnList = "product_id")
+})
 @Getter
 @Accessors(fluent = true)
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)

--- a/src/main/java/kr/hhplus/ecommerce/domain/product/ProductRepository.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/product/ProductRepository.java
@@ -7,4 +7,6 @@ public interface ProductRepository {
     Optional<Product> findById(long id);
     List<Product> findAll();
     List<Product> findAllById(List<Long> ids);
+    List<Long> findAllIds(int page, int size);
+    long count();
 } 

--- a/src/main/java/kr/hhplus/ecommerce/domain/statistics/DailyProductSales.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/statistics/DailyProductSales.java
@@ -1,0 +1,36 @@
+package kr.hhplus.ecommerce.domain.statistics;
+
+import jakarta.persistence.*;
+import kr.hhplus.ecommerce.common.entity.BaseEntity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+
+import java.time.LocalDate;
+
+@Entity(name = "daily_product_sales")
+@Table(
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_daily_product_sales_aggregation_date_product_id", columnNames = {"aggregationDate", "productId"}),
+    },
+    indexes = @Index(name = "dps_covering_index", columnList = "aggregationDate, productId, orderCount")
+)
+@Getter
+@Accessors(fluent = true)
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class DailyProductSales extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private LocalDate aggregationDate;
+    private long productId;
+    private long orderCount;
+    
+    public DailyProductSales(LocalDate aggregationDate,
+                             long productId,
+                             long orderCount) {
+        this.aggregationDate = aggregationDate;
+        this.productId = productId;
+        this.orderCount = orderCount;
+    }
+} 

--- a/src/main/java/kr/hhplus/ecommerce/domain/statistics/DailyProductSalesRepository.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/statistics/DailyProductSalesRepository.java
@@ -1,0 +1,11 @@
+package kr.hhplus.ecommerce.domain.statistics;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface DailyProductSalesRepository {
+    List<DailyProductSales> aggregate(LocalDate date, List<Long> productIds);
+    void createAll(List<DailyProductSales> dailyProductSalesList);
+    void deleteAllByAggregationDate(LocalDate aggregationDate);
+    List<Long> findTopSellingProductIds(LocalDate from, LocalDate to, int limit);
+}

--- a/src/main/java/kr/hhplus/ecommerce/domain/statistics/DailyProductSalesService.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/statistics/DailyProductSalesService.java
@@ -1,0 +1,40 @@
+package kr.hhplus.ecommerce.domain.statistics;
+
+import kr.hhplus.ecommerce.domain.product.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DailyProductSalesService {
+    static final int CHUNK_SIZE = 1000;
+    private final DailyProductSalesRepository dailyProductSalesRepository;
+    private final ProductRepository productRepository;
+
+    public List<Long> findTopSellingProductIds(int limit) {
+        LocalDate from = LocalDate.now().minusMonths(1);
+        LocalDate to = LocalDate.now();
+        
+        return dailyProductSalesRepository.findTopSellingProductIds(from, to, limit);
+    }
+
+
+    @Transactional
+    public void aggregate(LocalDate from, LocalDate to) {
+        long totalProductCount = productRepository.count();
+
+        for (LocalDate date = from; !date.isAfter(to); date = date.plusDays(1)) {
+            dailyProductSalesRepository.deleteAllByAggregationDate(date);
+
+            for (int i = 0; (long) i * CHUNK_SIZE < totalProductCount; i ++) {
+                List<Long> productIds = productRepository.findAllIds(i, CHUNK_SIZE);
+                var chunk = dailyProductSalesRepository.aggregate(date, productIds);
+                dailyProductSalesRepository.createAll(chunk);
+            }
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/ecommerce/domain/user/User.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/user/User.java
@@ -1,5 +1,7 @@
 package kr.hhplus.ecommerce.domain.user;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -8,8 +10,6 @@ import kr.hhplus.ecommerce.common.entity.BaseEntity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
-
-import java.time.LocalDateTime;
 
 @Entity(name = "users")
 @Getter

--- a/src/main/java/kr/hhplus/ecommerce/infrastructure/product/ProductJpaRepository.java
+++ b/src/main/java/kr/hhplus/ecommerce/infrastructure/product/ProductJpaRepository.java
@@ -1,13 +1,14 @@
 package kr.hhplus.ecommerce.infrastructure.product;
 
+import kr.hhplus.ecommerce.domain.product.Product;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
 import java.util.List;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-import kr.hhplus.ecommerce.domain.product.Product;
-
-@Repository
 public interface ProductJpaRepository extends JpaRepository<Product, Long> {
     List<Product> findAllByIdIn(List<Long> ids);
+    @Query("SELECT p.id FROM products p")
+    List<Long> findAllIds(Pageable pageable);
 } 

--- a/src/main/java/kr/hhplus/ecommerce/infrastructure/product/ProductRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/ecommerce/infrastructure/product/ProductRepositoryImpl.java
@@ -1,13 +1,14 @@
 package kr.hhplus.ecommerce.infrastructure.product;
 
-import java.util.List;
-import java.util.Optional;
-
-import org.springframework.stereotype.Repository;
-
 import kr.hhplus.ecommerce.domain.product.Product;
 import kr.hhplus.ecommerce.domain.product.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -27,5 +28,15 @@ public class ProductRepositoryImpl implements ProductRepository {
     @Override
     public List<Product> findAllById(List<Long> ids) {
         return productJpaRepository.findAllByIdIn(ids);
+    }
+
+    @Override
+    public List<Long> findAllIds(int page, int size) {
+        return productJpaRepository.findAllIds(PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "id")));
+    }
+
+    @Override
+    public long count() {
+        return productJpaRepository.count();
     }
 } 

--- a/src/main/java/kr/hhplus/ecommerce/infrastructure/statistics/DailyProductSalesRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/ecommerce/infrastructure/statistics/DailyProductSalesRepositoryImpl.java
@@ -1,0 +1,86 @@
+package kr.hhplus.ecommerce.infrastructure.statistics;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.hhplus.ecommerce.domain.order.Order;
+import kr.hhplus.ecommerce.domain.statistics.DailyProductSales;
+import kr.hhplus.ecommerce.domain.statistics.DailyProductSalesRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static kr.hhplus.ecommerce.domain.order.QOrder.order;
+import static kr.hhplus.ecommerce.domain.order.QOrderItem.orderItem;
+import static kr.hhplus.ecommerce.domain.product.QProductOption.productOption;
+import static kr.hhplus.ecommerce.domain.statistics.QDailyProductSales.dailyProductSales;
+
+@Repository
+@RequiredArgsConstructor
+public class DailyProductSalesRepositoryImpl implements DailyProductSalesRepository {
+    private final JPAQueryFactory queryFactory;
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Override
+    public List<DailyProductSales> aggregate(LocalDate aggregationDate, List<Long> productIds) {
+        return queryFactory.select(Projections.constructor(
+                DailyProductSales.class,
+                Expressions.constant(aggregationDate),
+                productOption.product.id,
+                orderItem.count()
+            ))
+            .from(order)
+            .join(order.items, orderItem)
+            .join(productOption).on(orderItem.productOptionId.eq(productOption.id))
+            .where(
+                order.createdAt.between(aggregationDate.atStartOfDay(), aggregationDate.plusDays(1).atStartOfDay()),
+                order.status.eq(Order.Status.COMPLETED),
+                productOption.product.id.in(productIds)
+            )
+            .groupBy(productOption.product.id)
+            .fetch();
+    }
+
+    @Override
+    public void createAll(List<DailyProductSales> list) {
+        if (list.isEmpty()) {
+            return;
+        }
+
+        jdbcTemplate.batchUpdate(
+            """
+            INSERT INTO daily_product_sales (aggregation_date, product_id, order_count)
+            VALUES (:aggregationDate, :productId, :orderCount)
+            """,
+            list.stream()
+                .map(BeanPropertySqlParameterSource::new)
+                .toArray(SqlParameterSource[]::new)
+        );
+    }
+
+    @Override
+    public void deleteAllByAggregationDate(LocalDate aggregationDate) {
+        String sql = "DELETE FROM daily_product_sales WHERE aggregation_date = :aggregationDate";
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue("aggregationDate", aggregationDate);
+        jdbcTemplate.update(sql, params);
+    }
+
+    @Override
+    public List<Long> findTopSellingProductIds(LocalDate from, LocalDate to, int limit) {
+        return queryFactory
+            .select(dailyProductSales.productId)
+            .from(dailyProductSales)
+            .where(dailyProductSales.aggregationDate.between(from, to))
+            .groupBy(dailyProductSales.productId)
+            .orderBy(dailyProductSales.orderCount.sum().desc())
+            .limit(limit)
+            .fetch();
+    }
+}

--- a/src/test/java/kr/hhplus/ecommerce/application/order/OrderFacadeIntegrationTest.java
+++ b/src/test/java/kr/hhplus/ecommerce/application/order/OrderFacadeIntegrationTest.java
@@ -3,6 +3,7 @@ package kr.hhplus.ecommerce.application.order;
 import kr.hhplus.ecommerce.common.IntegrationTestContext;
 import kr.hhplus.ecommerce.common.exception.DomainException;
 import kr.hhplus.ecommerce.domain.coupon.*;
+import kr.hhplus.ecommerce.domain.order.Order;
 import kr.hhplus.ecommerce.domain.order.OrderCommand;
 import kr.hhplus.ecommerce.domain.order.OrderVo;
 import kr.hhplus.ecommerce.domain.point.UserPoint;
@@ -15,6 +16,7 @@ import kr.hhplus.ecommerce.domain.user.User;
 import kr.hhplus.ecommerce.domain.user.UserFixture;
 import kr.hhplus.ecommerce.infrastructure.coupon.CouponJpaRepository;
 import kr.hhplus.ecommerce.infrastructure.coupon.IssuedCouponJpaRepository;
+import kr.hhplus.ecommerce.infrastructure.order.OrderJpaRepository;
 import kr.hhplus.ecommerce.infrastructure.point.UserPointJpaRepository;
 import kr.hhplus.ecommerce.infrastructure.product.ProductJpaRepository;
 import kr.hhplus.ecommerce.infrastructure.product.ProductOptionJpaRepository;
@@ -27,6 +29,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 
 import static kr.hhplus.ecommerce.common.support.DomainStatus.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,6 +54,8 @@ class OrderFacadeIntegrationTest extends IntegrationTestContext {
     private CouponJpaRepository couponJpaRepository;
     @Autowired
     private IssuedCouponJpaRepository issuedCouponJpaRepository;
+    @Autowired
+    private OrderJpaRepository orderJpaRepository;
 
     private User user;
     private UserPoint userPoint;
@@ -269,6 +275,254 @@ class OrderFacadeIntegrationTest extends IntegrationTestContext {
             // 포인트가 사용되지 않았는지 확인
             UserPoint updatedPoint = userPointJpaRepository.findById(userPoint.id()).orElseThrow();
             assertThat(updatedPoint.amount()).isEqualTo(userPoint.amount());
+        }
+    }
+
+    @Nested
+    @DisplayName("동시성 테스트")
+    class ConcurrencyTest {
+        @Test
+        void 제한된_재고의_상품을_여러_사용자가_동시에_주문하면_일부만_성공한다() throws InterruptedException {
+            // given
+            int initialStock = 5; // 초기 재고
+            Product product = productJpaRepository.save(new ProductFixture().setId(null).setPrice(5000).create());
+            ProductOption productOption = productOptionJpaRepository.save(
+                new ProductOptionFixture()
+                    .setId(null)
+                    .setProduct(product)
+                    .setStock(initialStock)
+                    .create()
+            );
+
+            // 10명의 사용자 생성
+            User[] users = new User[10];
+            for (int i = 0; i < users.length; i++) {
+                users[i] = userJpaRepository.save(new UserFixture().setId(null).create());
+
+                // 각 사용자에게 충분한 포인트 지급
+                userPointJpaRepository.save(
+                    new UserPointFixture()
+                        .setId(null)
+                        .setUserId(users[i].id())
+                        .setAmount(50000)
+                        .create()
+                );
+            }
+
+            int threadCount = 10;
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            // when
+            runConcurrent(threadCount, (index) -> {
+                try {
+                    OrderCommand.Create command = new OrderCommand.Create(
+                        users[index].id(),
+                        List.of(new OrderCommand.Create.OrderItem(productOption.id(), 1)),
+                        Optional.empty() // 쿠폰 미사용
+                    );
+
+                    orderFacade.process(command);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                }
+            });
+
+            // then
+            Optional<ProductOption> updatedOption = productOptionJpaRepository.findById(productOption.id());
+            assertThat(updatedOption).isPresent();
+            assertThat(updatedOption.get().stock()).isEqualTo(0); // 모든 재고가 소진됨
+
+            assertThat(successCount.get()).isEqualTo(initialStock); // 성공 개수는 초기 재고와 같아야 함
+            assertThat(failCount.get()).isEqualTo(threadCount - initialStock); // 나머지는 실패
+
+            // 성공한 주문 확인
+            List<Order> orders = orderJpaRepository.findAll();
+            assertThat(orders).hasSize(initialStock);
+        }
+
+        @Test
+        void 제한된_포인트로_여러_주문을_동시에_시도하면_일부만_성공한다() throws InterruptedException {
+            // given
+            int initialPoint = 30000; // 초기 포인트
+            int orderPrice = 10000; // 각 주문 가격
+
+            // 사용자 생성 및 포인트 설정
+            User user = userJpaRepository.save(new UserFixture().setId(null).create());
+            UserPoint userPoint = userPointJpaRepository.save(
+                new UserPointFixture()
+                    .setId(null)
+                    .setUserId(user.id())
+                    .setAmount(initialPoint)
+                    .create()
+            );
+
+            // 상품 생성 (충분한 재고)
+            Product product = productJpaRepository.save(new ProductFixture().setId(null).setPrice(orderPrice).create());
+            ProductOption productOption = productOptionJpaRepository.save(
+                new ProductOptionFixture()
+                    .setId(null)
+                    .setProduct(product)
+                    .setStock(100) // 충분한 재고
+                    .create()
+            );
+
+            int threadCount = 5; // 5개 주문 시도 (총 50,000 포인트 필요 > 초기 30,000)
+            int expectedSuccessCount = initialPoint / orderPrice;
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            // when
+            runConcurrent(threadCount, () -> {
+                try {
+                    OrderCommand.Create command = new OrderCommand.Create(
+                        user.id(),
+                        List.of(new OrderCommand.Create.OrderItem(productOption.id(), 1)),
+                        Optional.empty() // 쿠폰 미사용
+                    );
+
+                    orderFacade.process(command);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                }
+            });
+
+            // then
+            // 포인트 잔액 확인
+            Optional<UserPoint> updatedPoint = userPointJpaRepository.findById(userPoint.id());
+            assertThat(updatedPoint).isPresent();
+            assertThat(updatedPoint.get().amount()).isEqualTo(0); // 모든 포인트 소진
+
+            // 주문 수 확인
+            List<Order> orders = orderJpaRepository.findAll();
+            assertThat(orders).hasSize(expectedSuccessCount);
+
+            assertThat(successCount.get()).isEqualTo(expectedSuccessCount);
+            assertThat(failCount.get()).isEqualTo(threadCount - expectedSuccessCount);
+        }
+
+        @Test
+        void 사용자_1명이_동일한_쿠폰으로_동시에_여러번_주문하면_일부만_성공한다() throws InterruptedException {
+            // given
+            int initialPoint = 30000; // 초기 포인트
+            int productPrice = 10000; // 각 주문 가격
+            int discountAmount = coupon.discountAmount(); // 쿠폰 할인 금액
+            int finalAmount = productPrice - discountAmount; // 최종 결제 금액
+            int expectedUserPoint = initialPoint - finalAmount;
+
+            // 사용자 생성 및 포인트 설정
+            User user = userJpaRepository.save(new UserFixture().setId(null).create());
+            UserPoint userPoint = userPointJpaRepository.save(
+                new UserPointFixture()
+                    .setId(null)
+                    .setUserId(user.id())
+                    .setAmount(initialPoint)
+                    .create()
+            );
+
+            int threadCount = 5; // 5개 주문 시도 (총 50,000 포인트 필요 > 초기 30,000)
+            int expectedSuccessCount = 1;
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            // when
+            runConcurrent(threadCount, () -> {
+                try {
+                    OrderCommand.Create command = new OrderCommand.Create(
+                        user.id(),
+                        List.of(new OrderCommand.Create.OrderItem(productOption.id(), 1)),
+                        Optional.of(issuedCoupon.id()) // 쿠폰 사용
+                    );
+
+                    orderFacade.process(command);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                }
+            });
+
+            // then
+            assertThat(successCount.get()).isEqualTo(expectedSuccessCount);
+            assertThat(failCount.get()).isEqualTo(threadCount - expectedSuccessCount);
+
+            // 포인트 잔액 확인
+            Optional<UserPoint> updatedPoint = userPointJpaRepository.findById(userPoint.id());
+            assertThat(updatedPoint).isPresent();
+            assertThat(updatedPoint.get().amount()).isEqualTo(expectedUserPoint);
+
+            // 주문 수 확인
+            List<Order> orders = orderJpaRepository.findAll();
+            assertThat(orders).hasSize(expectedSuccessCount);
+
+            // 쿠폰 사용 확인
+            IssuedCoupon updatedCoupon = issuedCouponJpaRepository.findById(issuedCoupon.id()).orElseThrow();
+            assertThat(updatedCoupon.isUsed()).isTrue();
+        }
+
+        @Test
+        void 여러_사용자가_동시에_다양한_주문을_처리할_때_모든_리소스가_정확히_관리된다() throws InterruptedException {
+            // given
+            int userCount = 5;
+            User[] users = new User[userCount];
+            UserPoint[] userPoints = new UserPoint[userCount];
+
+            // 상품 생성
+            Product product = productJpaRepository.save(new ProductFixture().setId(null).setPrice(5000).create());
+            ProductOption productOption = productOptionJpaRepository.save(
+                new ProductOptionFixture()
+                    .setId(null)
+                    .setProduct(product)
+                    .setStock(100)
+                    .create()
+            );
+
+            // 사용자 및 포인트 설정
+            for (int i = 0; i < userCount; i++) {
+                users[i] = userJpaRepository.save(new UserFixture().setId(null).create());
+                userPoints[i] = userPointJpaRepository.save(
+                    new UserPointFixture()
+                        .setId(null)
+                        .setUserId(users[i].id())
+                        .setAmount(20000)
+                        .create()
+                );
+            }
+
+            // 주문 수량 배열 (1~3개)
+            int[] quantities = {1, 2, 3, 2, 1};
+            int totalQuantity = IntStream.of(quantities).sum(); // 총 주문 수량
+
+            // when
+            runConcurrent(userCount, (index) -> {
+                OrderCommand.Create command = new OrderCommand.Create(
+                    users[index].id(),
+                    List.of(new OrderCommand.Create.OrderItem(productOption.id(), quantities[index])),
+                    Optional.empty() // 쿠폰 미사용
+                );
+
+                orderFacade.process(command);
+            });
+
+            // then
+            // 재고 확인
+            Optional<ProductOption> updatedOption = productOptionJpaRepository.findById(productOption.id());
+            assertThat(updatedOption).isPresent();
+            assertThat(updatedOption.get().stock()).isEqualTo(100 - totalQuantity);
+
+            // 각 사용자의 포인트 잔액 확인
+            for (int i = 0; i < userCount; i++) {
+                Optional<UserPoint> updatedPoint = userPointJpaRepository.findById(userPoints[i].id());
+                int expectedRemainingPoints = 20000 - (quantities[i] * 5000);
+
+                assertThat(updatedPoint).isPresent();
+                assertThat(updatedPoint.get().amount()).isEqualTo(expectedRemainingPoints);
+            }
+
+            // 주문 확인
+            List<Order> orders = orderJpaRepository.findAll();
+            assertThat(orders).hasSize(userCount);
         }
     }
 } 

--- a/src/test/java/kr/hhplus/ecommerce/application/product/ProductFacadeTest.java
+++ b/src/test/java/kr/hhplus/ecommerce/application/product/ProductFacadeTest.java
@@ -1,32 +1,32 @@
 package kr.hhplus.ecommerce.application.product;
 
-import java.util.Arrays;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import kr.hhplus.ecommerce.domain.product.ProductService;
+import kr.hhplus.ecommerce.domain.product.ProductVo;
+import kr.hhplus.ecommerce.domain.product.ProductVoFixture;
+import kr.hhplus.ecommerce.domain.statistics.DailyProductSalesService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import kr.hhplus.ecommerce.domain.order.OrderService;
-import kr.hhplus.ecommerce.domain.product.ProductService;
-import kr.hhplus.ecommerce.domain.product.ProductVo;
-import kr.hhplus.ecommerce.domain.product.ProductVoFixture;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ProductFacadeTest {
     @InjectMocks
     private ProductFacade productFacade;
     @Mock
-    private OrderService orderService;
-    @Mock
     private ProductService productService;
+    @Mock
+    private DailyProductSalesService dailyProductSalesService;
 
     @Nested
     @DisplayName("인기 상품 목록 조회")
@@ -44,7 +44,7 @@ class ProductFacadeTest {
             ProductVo product3 = new ProductVoFixture().setId(3L).setName("인기 상품 3").create();
             List<ProductVo> products = List.of(product1, product2, product3);
             
-            when(orderService.findTopSellingProductIds(limit)).thenReturn(productIds);
+            when(dailyProductSalesService.findTopSellingProductIds(limit)).thenReturn(productIds);
             when(productService.findAllById(productIds)).thenReturn(products);
             
             // when
@@ -57,7 +57,7 @@ class ProductFacadeTest {
             assertThat(result.get(1).id()).isEqualTo(2L);
             assertThat(result.get(2).id()).isEqualTo(3L);
             
-            verify(orderService).findTopSellingProductIds(limit);
+            verify(dailyProductSalesService).findTopSellingProductIds(limit);
             verify(productService).findAllById(productIds);
         }
 
@@ -68,7 +68,7 @@ class ProductFacadeTest {
             int limit = 5;
             List<Long> emptyProductIds = List.of();
             
-            when(orderService.findTopSellingProductIds(limit)).thenReturn(emptyProductIds);
+            when(dailyProductSalesService.findTopSellingProductIds(limit)).thenReturn(emptyProductIds);
             when(productService.findAllById(emptyProductIds)).thenReturn(List.of());
             
             // when
@@ -78,7 +78,7 @@ class ProductFacadeTest {
             assertThat(result).isNotNull();
             assertThat(result).isEmpty();
             
-            verify(orderService).findTopSellingProductIds(limit);
+            verify(dailyProductSalesService).findTopSellingProductIds(limit);
             verify(productService).findAllById(emptyProductIds);
         }
     }

--- a/src/test/java/kr/hhplus/ecommerce/domain/coupon/IssuedCouponServiceIntegrationTest.java
+++ b/src/test/java/kr/hhplus/ecommerce/domain/coupon/IssuedCouponServiceIntegrationTest.java
@@ -20,6 +20,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static kr.hhplus.ecommerce.common.support.DomainStatus.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -276,7 +277,7 @@ class IssuedCouponServiceIntegrationTest extends IntegrationTestContext {
         void 이미_사용한_쿠폰_재사용시_실패() {
             // given
             long issuedCouponId = issuedCoupon.id();
-            
+
             // 우선 한번 사용
             issuedCouponService.use(issuedCouponId);
 
@@ -311,6 +312,166 @@ class IssuedCouponServiceIntegrationTest extends IntegrationTestContext {
                 .isInstanceOf(DomainException.class)
                 .hasFieldOrPropertyWithValue("status", EXPIRED_COUPON)
                 .hasMessage(EXPIRED_COUPON.message());
+        }
+    }
+
+    @Nested
+    @DisplayName("동시성 테스트")
+    class ConcurrencyTest {
+        @Test
+        void 한정수량_쿠폰을_동시에_발급받으면_일부만_성공한다() throws InterruptedException {
+            // given
+            int maxQuantity = 5; // 최대 발급 가능 수량
+            Coupon limitedCoupon = couponJpaRepository.save(
+                new CouponFixture()
+                    .setId(null)
+                    .setMaxQuantity(maxQuantity)
+                    .setIssuedQuantity(0)
+                    .create()
+            );
+
+            // 10명의 사용자 생성 (최대 발급 가능 수량보다 많음)
+            User[] users = new User[10];
+            for (int i = 0; i < users.length; i++) {
+                users[i] = userJpaRepository.save(
+                    new UserFixture().setId(null).create()
+                );
+            }
+
+            int threadCount = 10;
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            // when
+            runConcurrent(threadCount, (index) -> {
+                try {
+                    CouponCommand.Issue command = new CouponCommand.Issue(users[index].id(), limitedCoupon.id());
+                    issuedCouponService.issue(command);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                }
+            });
+
+            // then
+            Optional<Coupon> updatedCoupon = couponJpaRepository.findById(limitedCoupon.id());
+            assertThat(updatedCoupon).isPresent();
+            assertThat(updatedCoupon.get().issuedQuantity()).isEqualTo(maxQuantity);
+
+            assertThat(successCount.get()).isEqualTo(maxQuantity); // 성공 횟수 = maxQuantity
+            assertThat(failCount.get()).isEqualTo(threadCount - maxQuantity); // 실패 횟수 = (전체 요청 - 성공 횟수)
+            List<IssuedCoupon> allIssuedCoupons = issuedCouponJpaRepository.findAll();
+            assertThat(allIssuedCoupons).hasSize(maxQuantity);
+        }
+
+        @Test
+        void 여러_사용자가_동시에_쿠폰을_발급받으면_정확히_발급된다() throws InterruptedException {
+            // given
+            int initialQuantity = 0;
+            Coupon limitedCoupon = couponJpaRepository.save(
+                new CouponFixture()
+                    .setId(null)
+                    .setMaxQuantity(100)
+                    .setIssuedQuantity(initialQuantity)
+                    .create()
+            );
+
+            // 10명의 사용자 생성
+            User[] users = new User[10];
+            for (int i = 0; i < users.length; i++) {
+                users[i] = userJpaRepository.save(
+                    new UserFixture().setId(null).create()
+                );
+            }
+
+            int threadCount = 10;
+
+            // when
+            runConcurrent(threadCount, (index) -> {
+                CouponCommand.Issue command = new CouponCommand.Issue(users[index].id(), limitedCoupon.id());
+                issuedCouponService.issue(command);
+            });
+
+            // then
+            Optional<Coupon> updatedCoupon = couponJpaRepository.findById(limitedCoupon.id());
+            assertThat(updatedCoupon).isPresent();
+            assertThat(updatedCoupon.get().issuedQuantity()).isEqualTo(initialQuantity + threadCount);
+
+            for (User testUser : users) {
+                List<IssuedCoupon> issuedCoupons = issuedCouponJpaRepository.findByUserId(testUser.id());
+                assertThat(issuedCoupons).hasSize(1);
+                assertThat(issuedCoupons.get(0).coupon().id()).isEqualTo(limitedCoupon.id());
+                assertThat(issuedCoupons.get(0).isUsed()).isFalse();
+            }
+        }
+
+        @Test
+        void 동일한_쿠폰을_여러번_사용하면_한번만_성공한다() throws InterruptedException {
+            // given
+            // 쿠폰 발급
+            IssuedCoupon issuedCoupon = coupon.issue(user.id());
+            issuedCouponJpaRepository.save(issuedCoupon);
+
+            int threadCount = 10;
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            // when
+            runConcurrent(threadCount, () -> {
+                try {
+                    issuedCouponService.use(issuedCoupon.id());
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                }
+            });
+
+            // then
+            Optional<IssuedCoupon> updatedCoupon = issuedCouponJpaRepository.findById(issuedCoupon.id());
+            assertThat(updatedCoupon).isPresent();
+            assertThat(updatedCoupon.get().isUsed()).isTrue();
+            assertThat(updatedCoupon.get().usedAt()).isNotNull();
+
+            // 성공 횟수는 1이어야 함
+            assertThat(successCount.get()).isEqualTo(1);
+            // 실패 횟수는 9여야 함
+            assertThat(failCount.get()).isEqualTo(threadCount - 1);
+        }
+
+        @Test
+        void 여러_사용자가_각자의_쿠폰을_동시에_사용한다() throws InterruptedException {
+            // given
+            int userCount = 10;
+            User[] users = new User[userCount];
+            IssuedCoupon[] issuedCoupons = new IssuedCoupon[userCount];
+
+            // 10명의 사용자와 각 사용자에게 발급된 쿠폰 생성
+            for (int i = 0; i < userCount; i++) {
+                users[i] = userJpaRepository.save(
+                    new UserFixture().setId(null).create()
+                );
+
+                Coupon testCoupon = couponJpaRepository.save(
+                    new CouponFixture().setId(null).create()
+                );
+
+                issuedCoupons[i] = issuedCouponJpaRepository.save(
+                    testCoupon.issue(users[i].id())
+                );
+            }
+
+            // when
+            runConcurrent(userCount, (index) -> {
+                issuedCouponService.use(issuedCoupons[index].id());
+            });
+
+            // then
+            for (int i = 0; i < userCount; i++) {
+                Optional<IssuedCoupon> updatedCoupon = issuedCouponJpaRepository.findById(issuedCoupons[i].id());
+                assertThat(updatedCoupon).isPresent();
+                assertThat(updatedCoupon.get().isUsed()).isTrue();
+                assertThat(updatedCoupon.get().usedAt()).isNotNull();
+            }
         }
     }
 } 

--- a/src/test/java/kr/hhplus/ecommerce/domain/point/UserPointServiceIntegrationTest.java
+++ b/src/test/java/kr/hhplus/ecommerce/domain/point/UserPointServiceIntegrationTest.java
@@ -1,30 +1,26 @@
 package kr.hhplus.ecommerce.domain.point;
 
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import kr.hhplus.ecommerce.common.IntegrationTestContext;
+import kr.hhplus.ecommerce.common.exception.DomainException;
+import kr.hhplus.ecommerce.common.exception.NotFoundException;
+import kr.hhplus.ecommerce.domain.user.User;
+import kr.hhplus.ecommerce.domain.user.UserFixture;
+import kr.hhplus.ecommerce.infrastructure.point.UserPointHistoryJpaRepository;
+import kr.hhplus.ecommerce.infrastructure.point.UserPointJpaRepository;
+import kr.hhplus.ecommerce.infrastructure.user.UserJpaRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import kr.hhplus.ecommerce.common.IntegrationTestContext;
-import kr.hhplus.ecommerce.common.exception.DomainException;
-import kr.hhplus.ecommerce.common.exception.NotFoundException;
-import static kr.hhplus.ecommerce.common.support.DomainStatus.EXCEEDED_MAX_USER_POINT;
-import static kr.hhplus.ecommerce.common.support.DomainStatus.INSUFFICIENT_BALANCE;
-import static kr.hhplus.ecommerce.common.support.DomainStatus.INVALID_CHARGE_AMOUNT;
-import static kr.hhplus.ecommerce.common.support.DomainStatus.INVALID_USE_AMOUNT;
-import static kr.hhplus.ecommerce.common.support.DomainStatus.USER_NOT_FOUND;
-import static kr.hhplus.ecommerce.common.support.DomainStatus.USER_POINT_NOT_FOUND;
-import kr.hhplus.ecommerce.domain.user.User;
-import kr.hhplus.ecommerce.domain.user.UserFixture;
-import kr.hhplus.ecommerce.infrastructure.point.UserPointHistoryJpaRepository;
-import kr.hhplus.ecommerce.infrastructure.point.UserPointJpaRepository;
-import kr.hhplus.ecommerce.infrastructure.user.UserJpaRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static kr.hhplus.ecommerce.common.support.DomainStatus.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 class UserPointServiceIntegrationTest extends IntegrationTestContext {
     @Autowired
@@ -375,6 +371,250 @@ class UserPointServiceIntegrationTest extends IntegrationTestContext {
 
             List<UserPointHistory> histories = userPointHistoryJpaRepository.findAllByUserId(user.id());
             assertThat(histories).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("동시성 테스트")
+    class ConcurrencyTest {
+        @Test
+        void 잔액_부족시_동시_포인트_사용_실패() throws InterruptedException {
+            // given
+            int initialAmount = 500;
+            UserPoint userPoint = initUserPoint(new UserPointFixture().setAmount(initialAmount));
+
+            int threadCount = 10;
+            int useAmount = 100; // 총 사용 시도: 10 * 100 = 1000 > 초기값 500
+
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            // when
+            runConcurrent(threadCount, (index) -> {
+                try {
+                    UserPointCommand.Use command = new UserPointCommand.Use(user.id(), useAmount);
+                    userPointService.use(command);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                }
+            });
+
+            // then
+            UserPoint resultPoint = userPointJpaRepository.findById(userPoint.id()).orElseThrow();
+
+            // 5개만 성공할 수 있음 (500 / 100 = 5)
+            assertThat(successCount.get()).isEqualTo(5);
+            assertThat(failCount.get()).isEqualTo(5);
+            assertThat(resultPoint.amount()).isEqualTo(0); // 모든 잔액이 소진됨
+
+            List<UserPointHistory> histories = userPointHistoryJpaRepository.findAllByUserId(user.id());
+            assertThat(histories).hasSize(5); // 성공한 트랜잭션에 대한 히스토리만 생성
+            assertThat(histories).allMatch(h -> h.type() == UserPointHistory.Type.USE && h.amount() == useAmount);
+        }
+
+        @Test
+        void 포인트_충전시_최대_잔액에_도달할시_충전_실패() throws InterruptedException {
+            // given
+            UserPoint userPoint = initUserPoint(new UserPointFixture().setAmount(UserPoint.MAX_BALANCE - 300));
+            int threadCount = 10;
+            int chargeAmount = 100; // 총 충전 시도: 10 * 100 = 1000 > 최대값 1000
+
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            // when
+            runConcurrent(threadCount, (index) -> {
+                try {
+                    UserPointCommand.Charge command = new UserPointCommand.Charge(user.id(), chargeAmount);
+                    userPointService.charge(command);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                }
+            });
+
+            // then
+            UserPoint resultPoint = userPointJpaRepository.findById(userPoint.id()).orElseThrow();
+            assertThat(successCount.get()).isEqualTo(3); // 3개만 성공할 수 있음 (300 / 100 = 3)
+            assertThat(failCount.get()).isEqualTo(7); // 나머지 7개는 실패
+            assertThat(resultPoint.amount()).isEqualTo(UserPoint.MAX_BALANCE); // 최대 잔액에 도달함
+            List<UserPointHistory> histories = userPointHistoryJpaRepository.findAllByUserId(user.id());
+            assertThat(histories).hasSize(3); // 성공한 트랜잭션에 대한 히스토리만 생성
+            assertThat(histories).allMatch(h -> h.type() == UserPointHistory.Type.CHARGE && h.amount() == chargeAmount);
+        }
+
+        @Test
+        void 여러_스레드가_동시에_포인트_충전시_정확히_합산된다() throws InterruptedException {
+            // given
+            UserPoint userPoint = initUserPoint();
+            int initialAmount = userPoint.amount();
+            int threadCount = 10;
+            int chargeAmount = 100;
+            int expectedTotalAmount = initialAmount + (chargeAmount * threadCount);
+
+            // when
+            runConcurrent(threadCount, () -> {
+                UserPointCommand.Charge command = new UserPointCommand.Charge(user.id(), chargeAmount);
+                userPointService.charge(command);
+            });
+
+            // then
+            UserPoint resultPoint = userPointJpaRepository.findById(userPoint.id()).orElseThrow();
+            assertThat(resultPoint.amount()).isEqualTo(expectedTotalAmount);
+
+            List<UserPointHistory> histories = userPointHistoryJpaRepository.findAllByUserId(user.id());
+            assertThat(histories).hasSize(threadCount);
+            assertThat(histories).allMatch(h -> h.type() == UserPointHistory.Type.CHARGE);
+            assertThat(histories).allMatch(h -> h.amount() == chargeAmount);
+        }
+
+        @Test
+        void 여러_스레드가_동시에_포인트_사용시_정확히_차감된다() throws InterruptedException {
+            // given
+            UserPoint userPoint = initUserPoint(new UserPointFixture().setAmount(10000));
+            int initialAmount = userPoint.amount();
+            int threadCount = 10;
+            int useAmount = 100;
+            int expectedTotalAmount = initialAmount - (useAmount * threadCount);
+
+            // when
+            runConcurrent(threadCount, () -> {
+                UserPointCommand.Use command = new UserPointCommand.Use(user.id(), useAmount);
+                userPointService.use(command);
+            });
+
+            // then
+            UserPoint resultPoint = userPointJpaRepository.findById(userPoint.id()).orElseThrow();
+            assertThat(resultPoint.amount()).isEqualTo(expectedTotalAmount);
+
+            List<UserPointHistory> histories = userPointHistoryJpaRepository.findAllByUserId(user.id());
+            assertThat(histories).hasSize(threadCount);
+            assertThat(histories).allMatch(h -> h.type() == UserPointHistory.Type.USE);
+            assertThat(histories).allMatch(h -> h.amount() == useAmount);
+        }
+
+        @Test
+        void 서로_다른_값의_포인트_충전시_정확히_합산된다() throws InterruptedException {
+            // given
+            UserPoint userPoint = initUserPoint();
+            int initialAmount = userPoint.amount();
+            
+            int[] chargeAmounts = {100, 200, 300, 400, 500};
+            int expectedTotalChargeAmount = 0;
+            for (int amount : chargeAmounts) {
+                expectedTotalChargeAmount += amount;
+            }
+            int expectedTotalAmount = initialAmount + expectedTotalChargeAmount;
+
+            // when
+            runConcurrent(chargeAmounts.length, (index) -> {
+                UserPointCommand.Charge command = new UserPointCommand.Charge(user.id(), chargeAmounts[index]);
+                userPointService.charge(command);
+            });
+
+            // then
+            UserPoint resultPoint = userPointJpaRepository.findById(userPoint.id()).orElseThrow();
+            assertThat(resultPoint.amount()).isEqualTo(expectedTotalAmount);
+
+            List<UserPointHistory> histories = userPointHistoryJpaRepository.findAllByUserId(user.id());
+            assertThat(histories).hasSize(chargeAmounts.length);
+            
+            // 각 충전 금액별로 히스토리가 정확히 존재하는지 확인
+            for (int amount : chargeAmounts) {
+                assertThat(histories.stream()
+                    .filter(h -> h.type() == UserPointHistory.Type.CHARGE && h.amount() == amount)
+                    .count()).isEqualTo(1);
+            }
+        }
+
+        @Test
+        void 서로_다른_값의_포인트_사용시_정확히_차감된다() throws InterruptedException {
+            // given
+            UserPoint userPoint = initUserPoint(new UserPointFixture().setAmount(10000));
+            int initialAmount = userPoint.amount();
+            
+            int[] useAmounts = {100, 200, 300, 400, 500};
+            int expectedTotalUseAmount = 0;
+            for (int amount : useAmounts) {
+                expectedTotalUseAmount += amount;
+            }
+            int expectedTotalAmount = initialAmount - expectedTotalUseAmount;
+
+            // when
+            runConcurrent(useAmounts.length, (index) -> {
+                UserPointCommand.Use command = new UserPointCommand.Use(user.id(), useAmounts[index]);
+                userPointService.use(command);
+            });
+
+            // then
+            UserPoint resultPoint = userPointJpaRepository.findById(userPoint.id()).orElseThrow();
+            assertThat(resultPoint.amount()).isEqualTo(expectedTotalAmount);
+
+            List<UserPointHistory> histories = userPointHistoryJpaRepository.findAllByUserId(user.id());
+            assertThat(histories).hasSize(useAmounts.length);
+            
+            // 각 사용 금액별로 히스토리가 정확히 존재하는지 확인
+            for (int amount : useAmounts) {
+                assertThat(histories.stream()
+                    .filter(h -> h.type() == UserPointHistory.Type.USE && h.amount() == amount)
+                    .count()).isEqualTo(1);
+            }
+        }
+
+        @Test
+        void 충전과_사용이_동시에_발생할때_정확한_잔액을_유지한다() throws InterruptedException {
+            // given
+            UserPoint userPoint = initUserPoint(new UserPointFixture().setAmount(5000));
+            int initialAmount = userPoint.amount();
+            
+            int chargeAmount = 200;
+            int useAmount = 100;
+            
+            int chargeThreadCount = 5; // 총 충전: 200 * 5 = 1000
+            int useThreadCount = 10;   // 총 사용: 100 * 10 = 1000
+            
+            int expectedFinalAmount = initialAmount + (chargeAmount * chargeThreadCount) - (useAmount * useThreadCount);
+            
+            Runnable[] tasks = new Runnable[chargeThreadCount + useThreadCount];
+            
+            // 충전 태스크 설정
+            for (int i = 0; i < chargeThreadCount; i++) {
+                tasks[i] = () -> {
+                    UserPointCommand.Charge command = new UserPointCommand.Charge(user.id(), chargeAmount);
+                    userPointService.charge(command);
+                };
+            }
+            
+            // 사용 태스크 설정
+            for (int i = 0; i < useThreadCount; i++) {
+                tasks[chargeThreadCount + i] = () -> {
+                    UserPointCommand.Use command = new UserPointCommand.Use(user.id(), useAmount);
+                    userPointService.use(command);
+                };
+            }
+
+            // when
+            runConcurrent(tasks);
+
+            // then
+            UserPoint resultPoint = userPointJpaRepository.findById(userPoint.id()).orElseThrow();
+            assertThat(resultPoint.amount()).isEqualTo(expectedFinalAmount);
+
+            List<UserPointHistory> histories = userPointHistoryJpaRepository.findAllByUserId(user.id());
+            assertThat(histories).hasSize(chargeThreadCount + useThreadCount);
+            
+            // 충전 히스토리 확인
+            long chargeHistoryCount = histories.stream()
+                .filter(h -> h.type() == UserPointHistory.Type.CHARGE)
+                .count();
+            assertThat(chargeHistoryCount).isEqualTo(chargeThreadCount);
+            
+            // 사용 히스토리 확인
+            long useHistoryCount = histories.stream()
+                .filter(h -> h.type() == UserPointHistory.Type.USE)
+                .count();
+            assertThat(useHistoryCount).isEqualTo(useThreadCount);
         }
     }
 

--- a/src/test/java/kr/hhplus/ecommerce/domain/statistics/DailyProductSalesFixture.java
+++ b/src/test/java/kr/hhplus/ecommerce/domain/statistics/DailyProductSalesFixture.java
@@ -1,0 +1,26 @@
+package kr.hhplus.ecommerce.domain.statistics;
+
+import kr.hhplus.ecommerce.common.FixtureReflectionUtils;
+import kr.hhplus.ecommerce.common.TestFixture;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+public class DailyProductSalesFixture implements TestFixture<DailyProductSales> {
+    private Long id = 1L;
+    private LocalDate aggregationDate = LocalDate.of(2023, 1, 1);
+    private long productId = 1L;
+    private long orderCount = 10L;
+
+    @Override
+    public DailyProductSales create() {
+        DailyProductSales entity = new DailyProductSales();
+        FixtureReflectionUtils.reflect(entity, this);
+        return entity;
+    }
+} 

--- a/src/test/java/kr/hhplus/ecommerce/domain/statistics/DailyProductSalesServiceTest.java
+++ b/src/test/java/kr/hhplus/ecommerce/domain/statistics/DailyProductSalesServiceTest.java
@@ -1,0 +1,144 @@
+package kr.hhplus.ecommerce.domain.statistics;
+
+import kr.hhplus.ecommerce.domain.product.ProductRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static kr.hhplus.ecommerce.domain.statistics.DailyProductSalesService.CHUNK_SIZE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class DailyProductSalesServiceTest {
+    @InjectMocks
+    private DailyProductSalesService service;
+    @Mock
+    private DailyProductSalesRepository dailyProductSalesRepository;
+    @Mock
+    private ProductRepository productRepository;
+
+    @Nested
+    @DisplayName("인기 상품 ID 조회")
+    class FindTopSellingProductIdsTest {
+        @Test
+        void 인기_상품_조회_성공() {
+            // given
+            int limit = 5;
+            LocalDate from = LocalDate.now().minusMonths(1);
+            LocalDate to = LocalDate.now();
+            List<Long> expectedProductIds = List.of(1L, 2L, 3L);
+
+            given(dailyProductSalesRepository.findTopSellingProductIds(from, to, limit))
+                .willReturn(expectedProductIds);
+
+            // when
+            List<Long> result = service.findTopSellingProductIds(limit);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result).hasSize(3);
+            assertThat(result).isEqualTo(expectedProductIds);
+
+            verify(dailyProductSalesRepository).findTopSellingProductIds(from, to, limit);
+        }
+
+        @Test
+        void 인기_상품이_없을때() {
+            // given
+            int limit = 5;
+            LocalDate from = LocalDate.now().minusMonths(1);
+            LocalDate to = LocalDate.now();
+            List<Long> emptyProductIds = List.of();
+
+            given(dailyProductSalesRepository.findTopSellingProductIds(from, to, limit))
+                .willReturn(emptyProductIds);
+
+            // when
+            List<Long> result = service.findTopSellingProductIds(limit);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result).isEmpty();
+
+            verify(dailyProductSalesRepository).findTopSellingProductIds(from, to, limit);
+        }
+    }
+
+    @Nested
+    @DisplayName("상품 판매 통계 집계 테스트")
+    class AggregateTest {
+        @Test
+        void 집계_성공() {
+            // given
+            LocalDate date = LocalDate.of(2023, 1, 1);
+            long totalProductCount = CHUNK_SIZE * 2L;
+            List<Long> productIds1 = List.of(1L, 2L, 3L);
+            List<Long> productIds2 = List.of(4L, 5L, 6L);
+            
+            List<DailyProductSales> chunk1 = List.of(
+                new DailyProductSalesFixture().setProductId(1L).setOrderCount(10L).create(),
+                new DailyProductSalesFixture().setProductId(2L).setOrderCount(5L).create(),
+                new DailyProductSalesFixture().setProductId(3L).setOrderCount(8L).create()
+            );
+            
+            List<DailyProductSales> chunk2 = List.of(
+                new DailyProductSalesFixture().setProductId(4L).setOrderCount(3L).create(),
+                new DailyProductSalesFixture().setProductId(5L).setOrderCount(7L).create(),
+                new DailyProductSalesFixture().setProductId(6L).setOrderCount(2L).create()
+            );
+            
+            given(productRepository.count()).willReturn(totalProductCount);
+            given(productRepository.findAllIds(0, CHUNK_SIZE)).willReturn(productIds1);
+            given(productRepository.findAllIds(1, CHUNK_SIZE)).willReturn(productIds2);
+            given(dailyProductSalesRepository.aggregate(date, productIds1)).willReturn(chunk1);
+            given(dailyProductSalesRepository.aggregate(date, productIds2)).willReturn(chunk2);
+            
+            // when
+            service.aggregate(date, date);
+            
+            // then
+            verify(dailyProductSalesRepository).deleteAllByAggregationDate(date);
+            verify(productRepository).count();
+            verify(productRepository).findAllIds(0, CHUNK_SIZE);
+            verify(productRepository).findAllIds(1, CHUNK_SIZE);
+            verify(dailyProductSalesRepository).aggregate(date, productIds1);
+            verify(dailyProductSalesRepository).aggregate(date, productIds2);
+            verify(dailyProductSalesRepository).createAll(chunk1);
+            verify(dailyProductSalesRepository).createAll(chunk2);
+            verify(productRepository, times(2)).findAllIds(anyInt(), anyInt());
+            verify(dailyProductSalesRepository, times(2)).aggregate(any(), any());
+            verify(dailyProductSalesRepository, times(2)).createAll(any());
+        }
+        
+        @Test
+        void 상품이_없는_경우() {
+            // given
+            LocalDate date = LocalDate.of(2023, 1, 1);
+            long totalProductCount = 0L;
+            
+            given(productRepository.count()).willReturn(totalProductCount);
+            
+            // when
+            service.aggregate(date, date);
+            
+            // then
+            verify(dailyProductSalesRepository).deleteAllByAggregationDate(date);
+            verify(productRepository).count();
+            // 상품이 없으므로 findAllIds, aggregate, createAll은 호출되지 않아야 함
+            verify(productRepository, never()).findAllIds(anyInt(), anyInt());
+            verify(dailyProductSalesRepository, never()).aggregate(any(), any());
+            verify(dailyProductSalesRepository, never()).createAll(any());
+        }
+    }
+} 


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->
- 인덱스 추가: f7d6b247ace4ed58941c7309562d49440fa1a54a
- 동시성 테스트
  - 동시성 제어 테스트 함수: 57226261c42ad51b330a7ae5aed2dbdb5cee7993
  - 포인트: d9abf852aedf5bbcf57cbac0d79b52512aecd40b
  - 상품: d8de90fc86d7c987527349a23579ce6655bb253c
  - 쿠폰: f10feb41792070744ace040d379a0f04d5bb6ecc
  - 주문: 3f815b1a9ebe996daf1429214f55b1ea191196b7
- 상품 일일 통계 기능: 253264b23a3823ae27bd2e66b6fd46f03f19dc7e


- 보고서 바로가기: [링크](https://github.com/Moon-Jang/hhplus-e-commerce/blob/6eb3a0da0f9ca6b2b0ce4062460424dcd6336eb6/docs/%EC%84%9C%EB%B9%84%EC%8A%A4%EB%82%B4_%EB%B3%91%EB%AA%A9%ED%98%84%EC%83%81_%EA%B0%9C%EC%84%A0_%EB%B3%B4%EA%B3%A0%EC%84%9C.md)

- 로컬 DB에서 주문 100만건, 주문항목 150만건, 상품 12000건의 더미 데이터 삽입 후 과제를 진행하였습니다.

> 주문 항목 테이블 카디널리티


Key Name | Column | Cardinality | Index Type
-- | -- | -- | --
PRIMARY | id | 1,493,866 | BTREE
order_items_order_id_index | order_id | 994,890 | BTREE
order_items_product_option_id_index | product_option_id | 7,854 | BTREE

---
### **리뷰 포인트(질문)**
- 인기 상품 조회에 관한 병목 현상을 조사하였고 그에 대한 해결책을 구현하였습니다.

<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
과제를 끝까지 다 해낸 점
### Problem
<!--개선이 필요한 점-->
보고서 작성에 시간이 너무 오래걸린 점
### Try
<!-- 새롭게 시도할 점 -->
문서 작성에 익숙치 않아서 더 많이 써봐야될 것 같다.
