### PR TITLE
Step10

### DIFF
--- a/src/main/java/kr/hhplus/ecommerce/config/CorsFilter.java
+++ b/src/main/java/kr/hhplus/ecommerce/config/CorsFilter.java
@@ -1,0 +1,39 @@
+package kr.hhplus.ecommerce.config;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class CorsFilter implements Filter {
+    @Override
+    public void init(FilterConfig filterConfig) {}
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
+        throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) req;
+        HttpServletResponse response = (HttpServletResponse) res;
+
+        // CORS 설정 헤더 추가
+        response.setHeader("Access-Control-Allow-Origin", "*");
+        response.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, PATCH");
+        response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With");
+        response.setHeader("Access-Control-Allow-Credentials", "true");
+        response.setHeader("Access-Control-Max-Age", "3600");
+
+        // Preflight(OPTIONS) 요청은 바로 응답 처리
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            response.setStatus(HttpServletResponse.SC_OK);
+        } else {
+            chain.doFilter(req, res);
+        }
+    }
+}
+

--- a/src/main/java/kr/hhplus/ecommerce/config/UserValidationInterceptor.java
+++ b/src/main/java/kr/hhplus/ecommerce/config/UserValidationInterceptor.java
@@ -1,0 +1,50 @@
+package kr.hhplus.ecommerce.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.hhplus.ecommerce.common.exception.UnauthorizedException;
+import kr.hhplus.ecommerce.domain.user.UserService;
+import kr.hhplus.ecommerce.domain.user.UserVo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+import static kr.hhplus.ecommerce.common.support.ApplicationStatus.UNAUTHORIZED;
+
+@Component
+@RequiredArgsConstructor
+public class UserValidationInterceptor implements HandlerInterceptor {
+
+    private static final String PATH_VARS = HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE;
+    private final UserService userService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request,
+                             HttpServletResponse response,
+                             Object handler) throws IOException {
+        // PathVariable에서 userId 추출
+        Optional<Long> userId = Optional.ofNullable(request.getAttribute(PATH_VARS))
+            .filter(Map.class::isInstance)
+            .map(Map.class::cast)
+            .map(vars -> vars.get("userId"))
+            .map(String.class::cast)
+            .map(Long::valueOf);
+
+        userId.ifPresent(id -> {
+            Optional<UserVo> user = userService.findById(id);
+
+            if (user.isEmpty() || user.get().withdrawnAt() != null) {
+                throw new UnauthorizedException(UNAUTHORIZED);
+            }
+        });
+
+        return true;
+    }
+}

--- a/src/main/java/kr/hhplus/ecommerce/config/WebConfiguration.java
+++ b/src/main/java/kr/hhplus/ecommerce/config/WebConfiguration.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.time.LocalDate;
@@ -14,6 +15,8 @@ import java.time.format.DateTimeFormatter;
 @Configuration
 @RequiredArgsConstructor
 public class WebConfiguration implements WebMvcConfigurer {
+    private final UserValidationInterceptor userValidationInterceptor;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**").allowedMethods("*");
@@ -23,6 +26,12 @@ public class WebConfiguration implements WebMvcConfigurer {
     public void addFormatters(FormatterRegistry registry) {
         registry.addConverter(new LocalDateConverter());
         registry.addConverter(new LocalDateTimeConverter());
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(userValidationInterceptor)
+            .addPathPatterns("/**");
     }
 
     private static class LocalDateConverter implements Converter<String, LocalDate> {

--- a/src/main/java/kr/hhplus/ecommerce/domain/user/UserService.java
+++ b/src/main/java/kr/hhplus/ecommerce/domain/user/UserService.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 import static kr.hhplus.ecommerce.common.support.DomainStatus.USER_NOT_FOUND;
 
 @Service
@@ -18,5 +20,11 @@ public class UserService {
             .filter(User::isActive)
             .map(UserVo::from)
             .orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<UserVo> findById(long userId) {
+        return userRepository.findById(userId)
+            .map(UserVo::from);
     }
 }

--- a/src/main/java/kr/hhplus/ecommerce/interfaces/product/DailyProductSalesScheduler.java
+++ b/src/main/java/kr/hhplus/ecommerce/interfaces/product/DailyProductSalesScheduler.java
@@ -1,4 +1,4 @@
-package kr.hhplus.ecommerce.application.statistics;
+package kr.hhplus.ecommerce.interfaces.product;
 
 import kr.hhplus.ecommerce.domain.statistics.DailyProductSalesService;
 import lombok.RequiredArgsConstructor;
@@ -15,15 +15,15 @@ import java.time.LocalDate;
 public class DailyProductSalesScheduler {
 
     private final DailyProductSalesService dailyProductSalesService;
-    
+
     /**
-     * 매일 자정에 실행되어 전날의 판매 통계를 집계합니다.
+     * 매일 00:00에 일일 상품 판매 통계 집계 작업을 수행합니다.
+     * 환불 건이 존재할 수 있으므로 일주일 이전 데이터부터 새로 집계합니다.
      */
     @Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul")
     @SchedulerLock(name = "aggregateDailyProductSales", lockAtLeastFor = "PT10M")
     public void aggregateDailyProductSales() {
         log.info("일일 상품 판매 통계 집계 작업 시작");
-        // 환불 건이 존재할 수 있음으로 일주일 이전 데이터부터 새로 집계
         LocalDate from = LocalDate.now().minusDays(8);
         LocalDate to = LocalDate.now().minusDays(1);
 

--- a/src/test/java/kr/hhplus/ecommerce/interfaces/CorsFilterTest.java
+++ b/src/test/java/kr/hhplus/ecommerce/interfaces/CorsFilterTest.java
@@ -1,0 +1,48 @@
+package kr.hhplus.ecommerce.interfaces;
+
+import kr.hhplus.ecommerce.common.IntegrationTestContext;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class CorsFilterTest extends IntegrationTestContext {
+
+    @Test
+    void 일반_요청시_응답_헤더에_CORS_설정이_포함된다() throws Exception {
+        mockMvc.perform(get("/")
+                        .header("Origin", "http://example.com"))
+                .andExpect(status().isNotFound()) // 루트 경로에 매핑된 핸들러가 없다고 가정, 404 예상
+                .andExpect(header().exists("Access-Control-Allow-Origin"))
+                .andExpect(header().string("Access-Control-Allow-Origin", "*"))
+                .andExpect(header().exists("Access-Control-Allow-Methods"))
+                .andExpect(header().string("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, PATCH"))
+                .andExpect(header().exists("Access-Control-Allow-Headers"))
+                .andExpect(header().string("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With"))
+                .andExpect(header().exists("Access-Control-Allow-Credentials"))
+                .andExpect(header().string("Access-Control-Allow-Credentials", "true"))
+                .andExpect(header().exists("Access-Control-Max-Age"))
+                .andExpect(header().string("Access-Control-Max-Age", "3600"));
+    }
+
+    @Test
+    void Preflight_요청시_OK_상태코드와_전체_CORS_헤더를_응답한다() throws Exception {
+        mockMvc.perform(options("/")
+                        .header("Origin", "http://example.com")
+                        .header("Access-Control-Request-Method", "POST")
+                        .header("Access-Control-Request-Headers", "Content-Type, Authorization"))
+                .andExpect(status().isOk())
+                .andExpect(header().exists("Access-Control-Allow-Origin"))
+                .andExpect(header().string("Access-Control-Allow-Origin", "*"))
+                .andExpect(header().exists("Access-Control-Allow-Methods"))
+                .andExpect(header().string("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, PATCH"))
+                .andExpect(header().exists("Access-Control-Allow-Headers"))
+                .andExpect(header().string("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With"))
+                .andExpect(header().exists("Access-Control-Allow-Credentials"))
+                .andExpect(header().string("Access-Control-Allow-Credentials", "true"))
+                .andExpect(header().exists("Access-Control-Max-Age"))
+                .andExpect(header().string("Access-Control-Max-Age", "3600"));
+    }
+} 

--- a/src/test/java/kr/hhplus/ecommerce/interfaces/UserValidationInterceptorTest.java
+++ b/src/test/java/kr/hhplus/ecommerce/interfaces/UserValidationInterceptorTest.java
@@ -1,0 +1,102 @@
+package kr.hhplus.ecommerce.interfaces;
+
+import kr.hhplus.ecommerce.common.IntegrationTestContext;
+import kr.hhplus.ecommerce.common.web.ApiResponse;
+import kr.hhplus.ecommerce.domain.user.UserService;
+import kr.hhplus.ecommerce.domain.user.UserVo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(UserValidationInterceptorTest.TestController.class)
+class UserValidationInterceptorTest extends IntegrationTestContext {
+    private static final Long VALID_USER_ID = 1L;
+    private static final Long INVALID_USER_ID = 999L;
+    private static final Long WITHDRAWN_USER_ID = 2L;
+
+    @MockitoBean
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        UserVo validUser = new UserVo(VALID_USER_ID, "Valid User", null);
+        UserVo withdrawnUser = new UserVo(WITHDRAWN_USER_ID, "Withdrawn User", LocalDateTime.now());
+
+        given(userService.findById(VALID_USER_ID)).willReturn(Optional.of(validUser));
+        given(userService.findById(INVALID_USER_ID)).willReturn(Optional.empty());
+        given(userService.findById(WITHDRAWN_USER_ID)).willReturn(Optional.of(withdrawnUser));
+    }
+
+    @Test
+    @DisplayName("경로 변수에 유효한 userId가 있으면 검증 성공 후 200 OK 응답")
+    void when_validUserIdInPath_then_validationSucceeds() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(get("/test/users/{userId}", VALID_USER_ID));
+
+        // then
+        result.andExpect(status().isOk());
+        verify(userService).findById(VALID_USER_ID);
+    }
+
+    @Test
+    @DisplayName("경로 변수에 유효하지 않은 userId가 있으면 검증 실패 후 401 Unauthorized 응답")
+    void when_invalidUserIdInPath_then_validationFailsWithUnauthorized() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(get("/test/users/{userId}", INVALID_USER_ID));
+
+        // then
+        result.andExpect(status().isUnauthorized());
+        verify(userService).findById(INVALID_USER_ID);
+    }
+
+    @Test
+    @DisplayName("경로 변수에 탈퇴한 userId가 있으면 검증 실패 후 401 Unauthorized 응답")
+    void when_withdrawnUserIdInPath_then_validationFailsWithUnauthorized() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(get("/test/users/{userId}", WITHDRAWN_USER_ID));
+
+        // then
+        result.andExpect(status().isUnauthorized());
+        verify(userService).findById(WITHDRAWN_USER_ID);
+    }
+
+    @Test
+    @DisplayName("요청에 userId 정보가 없으면 검증 없이 200 OK 응답")
+    void when_noUserId_then_noValidationAndSucceeds() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(get("/test/no-user"));
+
+        // then
+        result.andExpect(status().isOk());
+        verify(userService, never()).findById(anyLong());
+    }
+
+    @RestController
+    static class TestController {
+        @GetMapping("/test/users/{userId}")
+        public ApiResponse<Void> getUserByPath(@PathVariable Long userId) {
+            return ApiResponse.success();
+        }
+
+        @GetMapping("/test/no-user")
+        public ApiResponse<Void> noUser() {
+            return ApiResponse.success();
+        }
+    }
+} 


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

CORS 필터 추가: e7cd3c86851ff276edc36afe1527d8bfc0a5066d
유저 인증 인터셉터 추가: a9f7f83160dbb07ecfd27af8b615c1eaa0716c6a
상품 통계 스케줄러: 8661fc1d744ab34871ed59d23b0d08bcf8ab82ff

---
### **리뷰 포인트(질문)**
- 비관적락을 사용중인 재고차감 기능에 분산락(Redis)를 도입한다고 했을때 비관적락은 제거되나요?
  - 분산락만 사용한다면 락 경합으로 인한 DB 부하를 줄일 수는 있겠지만 제가 생각을땐 비관적락이 최종 방어선이라는 느낌이 들어서 남겨나야되는게 아닌가 생각이 들었습니다

<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
- 과제를 모두 완료했다.
- 밤을 새지 않았다!

### Problem
<!--개선이 필요한 점-->
- 보고서 작성에 시간이 너무 많이 소요된다.

### Try
<!-- 새롭게 시도할 점 -->
- 문서 작성 연습
---
### 테스트 완료

<img width="662" alt="image" src="https://github.com/user-attachments/assets/d311ad3c-53fe-43ef-a9fa-a3ca659e0eae" />